### PR TITLE
[ein]: add darwin paths for clang runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,12 +161,14 @@ find_package(Doxygen)
 
 find_library(COMPILER_RT_BUILTINS
   NAMES clang_rt.builtins-x86_64
+        clang_rt.osx
   PATHS /usr/lib/llvm-19/lib/clang/19/lib/linux
+        /usr/local/opt/llvm@19/lib/clang/19/lib/darwin
   NO_DEFAULT_PATH
 )
 
 if(NOT COMPILER_RT_BUILTINS)
-  message(FATAL_ERROR "clang_rt.builtins-x86_64 library not found")
+  message(FATAL_ERROR "clang_rt library not found")
 endif()
 
 add_library(compiler_rt_builtins INTERFACE)

--- a/pub/install.dox
+++ b/pub/install.dox
@@ -3,26 +3,32 @@
 \page installation_page Installation
 
 \internal
-  \license
-    SPDX-FileType: Source
-    SPDX-FileCopyrightText: 2024 Edward Kmett <ekmett@gmail.com>
+\license
+SPDX-FileType: Source
+SPDX-FileCopyrightText: 2024 Edward Kmett <ekmett@gmail.com>
     SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
-  \endlicense
-\endinternal
+    \endlicense
+    \endinternal
 
-\tableofcontents
+    \tableofcontents
 
-You'll need a fairly bleeding edge compiler and build system for this.
+    You'll need a fairly bleeding edge compiler and build system for this.
 
-\section install_ninja Ninja 1.12.1
+    \section install_ninja Ninja 1.12.1
 
-You'll want to upgrade <a href="https://ninja-build.org/">Ninja</a> to a version that supports scanning for C++ modules.
+    You'll want to upgrade <a href="https://ninja-build.org/">Ninja</a> to a version that supports scanning for C++ modules.
 
+ubuntu:
 \code{.bash}
 wget https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
 sudo apt-get install -y unzip
 sudo unzip ninja-linux.zip -d /usr/local/bin/
 sudo chmod +x /usr/local/bin/ninja
+\endcode
+
+macOS:
+\code{.bash}
+brew install ninja
 \endcode
 
 \section install_clang Clang++-19
@@ -31,6 +37,7 @@ Next you'll need a version of <a href="https://clang.llvm.org/">Clang++</a> (and
 
 `clang-tools-19` is required because we need `clang-scan-deps-19` to be installed for C++ modules support out of `CMake`.
 
+ubuntu:
 \code{.bash}
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
@@ -38,10 +45,18 @@ sudo ./llvm.sh 19
 sudo apt install clang-19 clang-tools-19 clangd-19 lldb-19 lld-19
 \endcode
 
+macOS:
+\code{.bash}
+brew install llvm@19
+export PATH="/usr/local/opt/llvm@19/bin:$PATH"
+ln -s /usr/local/opt/llvm@19/bin/clang++ /usr/local/opt/llvm@19/bin/clang++-19
+\endcode
+
 \section install_doxygen Doxygen 1.12.0
 
 Documentation requires <a href="https://www.doxygen.nl/">Doxygen</a> 1.12.0 or later.
 
+ubuntu:
 \code{.bash}
 sudo apt-get uninstall doxygen
 wget https://www.doxygen.nl/files/doxygen-1.12.0.linux.bin.tar.gz
@@ -51,26 +66,45 @@ sudo make install
 doxygen --version
 \endcode
 
+macOS:
+\code{.bash}
+wget --no-verbose https://www.doxygen.nl/files/Doxygen-1.12.0.dmg
+hdiutil attach Doxygen-1.12.0.dmg
+sudo ln -s /Applications/Doxygen.app/Contents/Resources/doxygen /usr/local/bin/doxygen
+\endcode
+
 \section install_cmake CMake 3.30.5
 
 We need a fairly modern <a href="https://cmake.org/">CMake</a> in order to get C++ modules support.
 
-```bash
+ubuntu:
+\code{.bash}
 sudo apt-get remove cmake
 wget https://cmake.org/files/v3.30/cmake-3.30.5-linux-x86_64.sh -O cmake-3.30.5.sh
 chmod +x cmake-3.30.5.sh
 sudo ./cmake-3.30.5.sh --prefix=/usr/local --exclude-subdir
 cmake --version # you may need to restart your shell
-```
+\endcode
+
+macOS:
+\code{.bash}
+brew install cmake
+\endcode
 
 \section install_ccache CCache
 
 <a href="https://ccache.dev/">CCache</a> makes development a lot faster and is use by the default `CMakePreset.json` preset.
 Not strictly necessary, but it is an easy win.
 
-```bash
+ubuntu:
+\code{.bash}
 sudo apt-get install -y ccache
-```
+\endcode
+
+macOS:
+\code{.bash}
+brew install ccache
+\endcode
 
 <div class="section_buttons">
 <table class="markdownTable">
@@ -78,7 +112,5 @@ sudo apt-get install -y ccache
 <tr class="markdownTableRowOdd"><td class="markdownTableBodyLeft">\ref license_page</td><td class="markdownTableBodyRight">\ref notes_page</td></tr>
 </table>
 </div>
-
-
 
 */


### PR DESCRIPTION
- add darwin options to find library `COMPILER_RT_BUILTINS`
- update the install instructions to include instructions for macOS