### PR TITLE
[ein]: generalize Doxyfile to accommodate external builds

### DIFF
--- a/.github/actions/setup/macos/build-tools/action.yml
+++ b/.github/actions/setup/macos/build-tools/action.yml
@@ -1,0 +1,24 @@
+name: 'install build tools'
+description: install cmake & ninja
+runs:
+  using: composite
+  steps:
+    - name: set tool path
+      run: |
+        echo "/usr/local/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: install cmake 3.30.5
+      run: |
+        brew install cmake
+        which cmake && cmake --version
+      shell: bash
+    - name: install ninja 1.12.1
+      run: |
+        brew install ninja
+        which ninja && ninja --version
+      shell: bash
+    - name: install ccache
+      run: |
+        brew install ccache
+        which ccache && ccache --version
+      shell: bash

--- a/.github/actions/setup/macos/compiler/action.yaml
+++ b/.github/actions/setup/macos/compiler/action.yaml
@@ -1,0 +1,24 @@
+name: 'install the compiler'
+description: install clang, llvm and doxygen
+runs:
+  using: composite
+  steps:
+    - name: set tool paths
+      run: |
+        echo "/usr/local/bin" >> $GITHUB_PATH
+        echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
+      shell: bash
+    - name: install clang 19
+      run: |
+        brew install llvm
+        ln -s /usr/local/opt/llvm/bin/clang++ /usr/local/opt/llvm/bin/clang++-19
+        which clang++-19 && clang++-19 --version
+      shell: bash
+    - name: install doxygen 1.12.0
+      run: |
+        wget --no-verbose https://www.doxygen.nl/files/Doxygen-1.12.0.dmg
+        hdiutil attach Doxygen-1.12.0.dmg
+        cp -R /Volumes/Doxygen/Doxygen.app /Applications/
+        sudo ln -s /Applications/Doxygen.app/Contents/Resources/doxygen /usr/local/bin/doxygen
+        which doxygen &&  doxygen --version
+      shell: bash

--- a/.github/actions/setup/ubuntu/build-tools/action.yml
+++ b/.github/actions/setup/ubuntu/build-tools/action.yml
@@ -9,6 +9,9 @@ runs:
         echo "/usr/local/bin" >> $GITHUB_PATH
         mkdir -p lib/install
       shell: bash
+    - name: install dot
+      run: sudo apt install graphviz
+      shell: bash
     - name: install cmake 3.30.5
       run: |
         cd lib/install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
         working-directory: '${{ steps.paths.outputs.gen }}'
         run: ctest -V
 
-  traditional-build:
-    name: Build without Docker
+  traditional-build-linux:
+    name: Build without Docker (linux)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +99,36 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ubuntu-latest-ccache
+      - name: cache lib/cache
+        id: libcache
+        uses: actions/cache@v4
+        with:
+          path: '${{ github.workspace }}/lib/cache'
+          key: '${{ runner.os }}-cache'
+      - name: set reusable strings
+        id: paths
+        run: echo "gen=${{ github.workspace }}/gen" >> "$GITHUB_OUTPUT"
+      - name: configure and build
+        run: make -C '${{ github.workspace }}'
+      - name: test
+        working-directory: ${{ steps.paths.outputs.gen }}
+        run: ctest -V
+      - name: setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: false # ${{ failure() }}
+        timeout-minutes: 10
+
+  traditional-build-macos:
+    name: Build without Docker (macos)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup/macos/compiler
+      - uses: ./.github/actions/setup/macos/build-tools
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: macos-13-ccache
       - name: cache lib/cache
         id: libcache
         uses: actions/cache@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(ENV{CCACHE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/.ccache")
 
 option(CODE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_TESTS "Enable tests" ON)
-option(PRECOMPILE_HEADERS "Use precompiled headers" ON)
+option(PRECOMPILE_HEADERS "Use precompiled headers" OFF)
 option(BUILD_NATIVE "Build for current host only" ON)
 option(ASAN "address sanitization" OFF)
 option(TSAN "thread sanitization" OFF)
@@ -286,7 +286,7 @@ endforeach()
 # Custom command to copy header files
 add_custom_command(
   OUTPUT ${OUTPUT_HEADER_FILES}
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SOURCE_HEADER_FILES} "${CMAKE_BINARY_DIR}/h"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SOURCE_HEADER_FILES} "${CMAKE_CURRENT_BINARY_DIR}/h"
   DEPENDS ${SOURCE_HEADER_FILES}
 )
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -137,7 +137,7 @@ if(DOXYGEN_FOUND)
     #WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating documentation"
     VERBATIM
-    DEPENDS "${CMAKE_BINARY_DIR}/h/config.hpp" apply_doxygen_awesome_patch copy_mathjax touch_nojekyll
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/../h/config.hpp" apply_doxygen_awesome_patch copy_mathjax touch_nojekyll
   )
 
   # Make sure the documentation target depends on DoxygenProject if we built it

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -5,27 +5,27 @@
 PROJECT_NAME   = @PROJECT_NAME@
 PROJECT_NUMBER = @PROJECT_VERSION@
 PROJECT_BRIEF  = @PROJECT_BRIEF@
-PROJECT_LOGO   = @CMAKE_SOURCE_DIR@/doc/assets/images/ein-logo.png
-PROJECT_ICON   = @CMAKE_SOURCE_DIR@/doc/assets/icons/favicon.ico
-IMAGE_PATH     = @CMAKE_SOURCE_DIR@/doc/assets
+PROJECT_LOGO   = @CMAKE_CURRENT_SOURCE_DIR@/assets/images/ein-logo.png
+PROJECT_ICON   = @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/favicon.ico
+IMAGE_PATH     = @CMAKE_CURRENT_SOURCE_DIR@/assets
 DOTFILE_DIRS   = @CMAKE_BINARY_DIR@/patched-dotfiles
 
 # inputs
-INPUT += @CMAKE_SOURCE_DIR@/LICENSE.md
-INPUT += @CMAKE_SOURCE_DIR@/CODE_OF_CONDUCT.md
-INPUT += @CMAKE_SOURCE_DIR@/CONTRIBUTING.md
-INPUT += @CMAKE_SOURCE_DIR@/SECURITY.md
-INPUT += @CMAKE_SOURCE_DIR@/src
-INPUT += @CMAKE_SOURCE_DIR@/doc
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/../LICENSE.md
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/../CODE_OF_CONDUCT.md
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/../CONTRIBUTING.md
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/../SECURITY.md
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/../src
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@
 INPUT += @CMAKE_BINARY_DIR@/h
 INPUT += @CMAKE_SOURCE_DIR@/t
 
 EXTENSION_MAPPING = cppm=C++
 FILE_PATTERNS = *.h *.hpp *.c *.cpp *.cppm *.dox *.md *.x=cpp
-FILTER_PATTERNS  = *.md=@CMAKE_SOURCE_DIR@/bin/gfm_preprocessor.sh
-FILTER_PATTERNS += *.cppm=@CMAKE_SOURCE_DIR@/bin/elifdef.sh
-FILTER_PATTERNS += *.cpp=@CMAKE_SOURCE_DIR@/bin/elifdef.sh
-FILTER_PATTERNS += *.hpp=@CMAKE_SOURCE_DIR@/bin/elifdef.sh
+FILTER_PATTERNS  = *.md=@CMAKE_CURRENT_SOURCE_DIR@/../bin/gfm_preprocessor.sh
+FILTER_PATTERNS += *.cppm=@CMAKE_CURRENT_SOURCE_DIR@/../bin/elifdef.sh
+FILTER_PATTERNS += *.cpp=@CMAKE_CURRENT_SOURCE_DIR@/../bin/elifdef.sh
+FILTER_PATTERNS += *.hpp=@CMAKE_CURRENT_SOURCE_DIR@/../bin/elifdef.sh
 STRIP_FROM_PATH = @CMAKE_BINARY_DIR@/ @CMAKE_SOURCE_DIR@/
 OUTPUT_DIRECTORY = @CMAKE_BINARY_DIR@/doc
 FULL_PATH_NAMES = NO
@@ -80,11 +80,11 @@ GENERATE_TREEVIEW      = YES
 DISABLE_INDEX          = NO
 FULL_SIDEBAR           = NO
 HTML_COLORSTYLE        = LIGHT
-HTML_HEADER            = @CMAKE_SOURCE_DIR@/doc/assets/header.html
-HTML_FOOTER            = @CMAKE_SOURCE_DIR@/doc/assets/footer.html
+HTML_HEADER            = @CMAKE_CURRENT_SOURCE_DIR@/assets/header.html
+HTML_FOOTER            = @CMAKE_CURRENT_SOURCE_DIR@/assets/footer.html
 LATEX_EMOJI_DIRECTORY  = @FETCHCONTENT_BASE_DIR@/github_emojis-src/
 #HTML_EXTRA_STYLESHEET  = @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen-awesome.css
-HTML_EXTRA_STYLESHEET  = @CMAKE_BINARY_DIR@/doc/doxygen-awesome.css
+HTML_EXTRA_STYLESHEET  = @CMAKE_CURRENT_BINARY_DIR@/doxygen-awesome.css
 HTML_EXTRA_STYLESHEET += @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen-awesome-sidebar-only.css
 HTML_EXTRA_STYLESHEET += @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen-awesome-sidebar-only-darkmode-toggle.css
 HTML_EXTRA_FILES       = @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen-awesome-darkmode-toggle.js
@@ -93,30 +93,30 @@ HTML_EXTRA_FILES      += @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen
 HTML_EXTRA_FILES      += @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen-awesome-interactive-toc.js
 HTML_EXTRA_FILES      += @FETCHCONTENT_BASE_DIR@/doxygen-awesome-css-src/doxygen-awesome-tabs.js
 
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/images/ein-logo.png
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/images/ein-logo.png
 
 # favicon support
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/icons/favicon.ico
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/icons/favicon-16x16.png
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/icons/favicon-32x32.png
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/icons/android-chrome-192x192.png
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/icons/android-chrome-512x512.png
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/icons/apple-touch-icon.png
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/site.web-manifest
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/favicon.ico
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/favicon-16x16.png
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/favicon-32x32.png
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/android-chrome-192x192.png
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/android-chrome-512x512.png
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/icons/apple-touch-icon.png
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/site.web-manifest
 
 # custom fonts
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/fonts/Hasklig-Regular.woff
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/fonts/Hasklig-Regular.woff2
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/fonts/Hasklig-It.woff
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/fonts/Hasklig-It.woff2
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/fonts/Hasklig-Bold.woff
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/fonts/Hasklig-Bold.woff2
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/fonts/Hasklig-Regular.woff
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/fonts/Hasklig-Regular.woff2
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/fonts/Hasklig-It.woff
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/fonts/Hasklig-It.woff2
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/fonts/Hasklig-Bold.woff
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/fonts/Hasklig-Bold.woff2
 
 # support perfetto traces
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/trace.js
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/trace.js
 
 # ensure the navbar is never empty
-HTML_EXTRA_FILES      += @CMAKE_SOURCE_DIR@/doc/assets/go-home.js
+HTML_EXTRA_FILES      += @CMAKE_CURRENT_SOURCE_DIR@/assets/go-home.js
 
 HTML_COPY_CLIPBOARD    = NO
 CREATE_SUBDIRS         = NO


### PR DESCRIPTION

this PR
  - works on Doxyfile.in so that when ein is hosted within a external project via `FetchContent/FetchContentCached` docs generation doesn't cause errors

  - takes care of install dot on ubuntu and in doing so removes a bunch of errors from the generate docs step
  
  - ~~fixes the `OUTPUT_HEADER_FILES` custom command to install into `CMAKE_CURRENT_BINARY_DIR` (rather than `CMAKE_BINARY_DIR`~~ 
  
  - disables `PRECOMPILE_HEADERS` by default. when enabled the external project encounters errors at link time 